### PR TITLE
Use amati[bot] for automated data refreshes and use CodeQL at more useful junctures

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,10 @@
 name: "CodeQL Advanced"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   schedule:
-    - cron: '35 2 * * 3'
+    - cron: '0 0 * * 1,4'
 
 jobs:
   analyze:

--- a/.github/workflows/data-refresh.yaml
+++ b/.github/workflows/data-refresh.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
       with:
-        token: ${{ secrets.DATA_REFRESH_PAT }}
+        token: ${{ secrets.BOT_TOKEN }}
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v6
@@ -33,8 +33,8 @@ jobs:
 
     - name: Configure Git
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.email "218805929+amati-bot@users.noreply.github.com"
+        git config --local user.name "amati[bot]"
 
     - name: Create and switch to new branch
       run: |
@@ -92,7 +92,7 @@ jobs:
       if: steps.run_script.outputs.script_exit_code == '0' && steps.check_changes.outputs.changes == 'true'
       run: |
         git add .
-        git commit -m "chore: refresh data - automated update
+        git commit -m "refresh data - automated update
 
         This commit contains automated data refresh changes.
         Generated on: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
@@ -102,12 +102,12 @@ jobs:
       if: steps.run_script.outputs.script_exit_code == '0' && steps.check_changes.outputs.changes == 'true'
       uses: actions/github-script@v8
       with:
-        github-token: ${{ secrets.DATA_REFRESH_PAT }}
+        github-token: ${{ secrets.BOT_TOKEN }}
         script: |
           const { data: pullRequest } = await github.rest.pulls.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: `chore: automated data refresh`,
+            title: `Automated data refresh`,
             head: process.env.BRANCH_NAME,
             base: 'main',
             body: `## Automated Data Refresh
@@ -147,7 +147,7 @@ jobs:
       if: failure() && steps.run_script.outputs.script_exit_code != '0'
       uses: actions/github-script@v8
       with:
-        github-token: ${{ secrets.DATA_REFRESH_PAT }}
+        github-token: ${{ secrets.BOT_TOKEN }}
         script: |
           const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           


### PR DESCRIPTION
CodeQL running after a push when it's run as the PR was created makes less sense, time from PR creation to merge is minimal.